### PR TITLE
Fix: redirect view does not pass GET parameters.

### DIFF
--- a/dynamic_subdomains/views.py
+++ b/dynamic_subdomains/views.py
@@ -1,6 +1,9 @@
+import urllib
+
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 
 from .forms import RedirectForm
+
 
 def redirect(request):
     form = RedirectForm(request.GET)
@@ -8,8 +11,18 @@ def redirect(request):
     if not form.is_valid():
         return HttpResponseBadRequest(repr(form.errors))
 
-    response = HttpResponseRedirect(form.cleaned_data['path'])
+    parameters = request.GET.copy()
+    for key in ['domain', 'path']:
+        if key in parameters:
+            del parameters[key]
+    parameters = urllib.urlencode(parameters)
+
+    url = form.cleaned_data['path']
+    if parameters:
+        url = '%s?%s' % (url, parameters)
+
+    response = HttpResponseRedirect(url)
     response.set_cookie('_domain', form.cleaned_data['domain'])
-    response.status_code = 307 # Re-submit POST requests
+    response.status_code = 307  # Re-submit POST requests
 
     return response

--- a/setup.py
+++ b/setup.py
@@ -18,4 +18,5 @@ setup(
             'templates/*/*.html',
         ],
     },
+    requires=['django'],
 )


### PR DESCRIPTION
There was problem with using template tag `domain_url` in html form action attribute, because returned url used to redirect to given path with proper domain, was containing domain and path but in case when request had GET parameters, they were omitted. This commit fix this issue.
